### PR TITLE
feat: respect MSDO_BREAK env var to allow build failure on detections

### DIFF
--- a/src/msdo-client.ts
+++ b/src/msdo-client.ts
@@ -125,7 +125,9 @@ export async function run(inputArgs: string[], telemetryEnvironment: string = 'g
         // These args either aren't compatible with or mean nothing in the
         // `guardian upload` command scenario
         if (!isUploadExisting) {
-            args.push('--not-break-on-detections');
+            if (!common.getMsdoBreakEnvironmentVariable()) {
+                args.push('--not-break-on-detections');
+            }
 
             let sarifFile : string = path.join(process.env.GITHUB_WORKSPACE, '.gdn', 'msdo.sarif');
             core.debug(`sarifFile = ${sarifFile}`);


### PR DESCRIPTION
## Summary
- Conditionally skip `--not-break-on-detections` flag when `MSDO_BREAK=true` env var is set
- Uses the existing but previously unused `getMsdoBreakEnvironmentVariable()` from `msdo-common.ts`
- Fixes https://github.com/microsoft/security-devops-action/issues/156

## Context
The `--not-break-on-detections` flag is currently added unconditionally for all non-upload runs, making it impossible for users to fail builds on vulnerability detections. The infrastructure to control this via `MSDO_BREAK` env var already existed in `msdo-common.ts` but was never used in `msdo-client.ts`.

## Change
Single-line change in `msdo-client.ts`: wrap `args.push('--not-break-on-detections')` in `if (!common.getMsdoBreakEnvironmentVariable())`.

## Backward compatible
Default behavior unchanged — `MSDO_BREAK` defaults to false, so the flag is still added unless explicitly opted in.

## Test plan
- [ ] Default: `MSDO_BREAK` not set → `--not-break-on-detections` added (unchanged behavior)
- [ ] Opt-in: `MSDO_BREAK=true` → flag NOT added, build fails on detections
- [ ] Upload path unaffected